### PR TITLE
Fix Poster failure with withdrawn records

### DIFF
--- a/Scraper.py
+++ b/Scraper.py
@@ -222,6 +222,14 @@ class Scraper:
             input_df.drop(drops, inplace=True)
             print(f"Appending : {','.join([str(add) for add in adds])}")
             revised_df = input_df.append(entry_df.loc[adds])
+
+            # Sponsoring organizations is always 'PPPL',
+            # DOE Contact is often the case (for starter), and
+            # Datatype seems to be placeholder - not included in OSTI metadata
+            revised_df.loc[adds, 'Sponsoring Organizations'] = 'PPPL'
+            revised_df.loc[adds, 'DOE Contract'] = 'AC02-09CH11466***'
+            revised_df.loc[adds, 'Datatype'] = 'AS'
+
             revised_df.to_csv(self.form_input, sep='\t')
         else:
             raise FileNotFoundError(f"WARNING: {self.form_input} does not exist!")

--- a/Scraper.py
+++ b/Scraper.py
@@ -226,9 +226,9 @@ class Scraper:
             # Sponsoring organizations is always 'PPPL',
             # DOE Contact is often the case (for starter), and
             # Datatype seems to be placeholder - not included in OSTI metadata
-            revised_df.loc[adds, 'Sponsoring Organizations'] = 'PPPL'
-            revised_df.loc[adds, 'DOE Contract'] = 'AC02-09CH11466***'
-            revised_df.loc[adds, 'Datatype'] = 'AS'
+            revised_df.loc[adds, 'Sponsoring Organizations'] = "USDOE Office of Science (SC)"
+            revised_df.loc[adds, 'DOE Contract'] = "AC02-09CH11466***"
+            revised_df.loc[adds, 'Datatype'] = "AS"
 
             revised_df.to_csv(self.form_input, sep='\t')
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ requests
 pandas
 dicttoxml
 git+https://github.com/doecode/ostiapi.git
-    


### PR DESCRIPTION
Closes #49 

This PR does two things:
1. It adds a new method in `Scraper`, `update_form_input`, to update/create the form_input.tsv. Primarily, this remove DataSpace records where they have been withdrawn, which is primarily causing #49. Second, it also adds new entries. By addressing both record updates, this removes the need to _manually_ update the TSV file, particularly with new entries.
2. Second, with new records, it automatically updates the DOE metadata (sponsoring organizations, funding, and datatype) with default settings. This ensure that `Poster` will run successfully.

Note that this is toward having the ability for CI to scrape these data and update records, removing the need for manual involvements as much as possible.