### PR TITLE
Add user prompt for test or prod mode

### DIFF
--- a/Poster.py
+++ b/Poster.py
@@ -184,4 +184,14 @@ Choose one of the following options:
     else:
         mode = args[1][2:]
         p = Poster(mode)
-        p.run_pipeline()
+        if mode in ['test', 'prod']:
+            print(f"WARNING: Running this script in {mode} mode will "
+                  "trigger emails to PPPL and OSTI!")
+            user_response = input(
+                "Are you sure you wish you proceed? (Enter 'Yes'/'yes') "
+            )
+        print(f"User response: {user_response}")
+        if user_response.lower() == 'yes':
+            p.run_pipeline()
+        else:
+            print("Exiting!!! You must respond with a Yes/yes")

--- a/Poster.py
+++ b/Poster.py
@@ -184,6 +184,8 @@ Choose one of the following options:
     else:
         mode = args[1][2:]
         p = Poster(mode)
+        if mode == 'dry-run':
+            user_response = 'yes'
         if mode in ['test', 'prod']:
             print(f"WARNING: Running this script in {mode} mode will "
                   "trigger emails to PPPL and OSTI!")


### PR DESCRIPTION
Closes #53

A user prompt is added to request a response before triggering the `Poster.run_pipeline` method, which executes the POST submissions.

The prompt is the following:
```
WARNING: Running this script in test mode will trigger emails to PPPL and OSTI!
Are you sure you wish you proceed? (Enter 'Yes'/'yes')
```

Any response other than a lower-cased permutation (e.g., YES, Yes, yes) of "yes", triggers the following:
```
WARNING: Running this script in test mode will trigger emails to PPPL and OSTI!
Are you sure you wish you proceed? (Enter 'Yes'/'yes') no
User response: no
Exiting!!! You must response with a Yes/yes
```
