### PR TITLE
Require minimum credentials for test/prod mode

### DIFF
--- a/Poster.py
+++ b/Poster.py
@@ -27,18 +27,17 @@ class Poster:
         assert os.path.exists(data_dir)
         assert os.path.exists(response_dir)
 
-        # Ensure environment variables are prepared
-        environment_vars = ['OSTI_USERNAME_TEST', 'OSTI_PASSWORD_TEST',
-         'OSTI_USERNAME_PROD', 'OSTI_PASSWORD_PROD']
-        assert all([var in os.environ for var in environment_vars]), 'All four environment variables need to be set. See the README for more information.'
+        # Ensure minimum (test/prod) environment variables are prepared
+        environment_vars = [v + f'_{mode.upper()}' for
+                            v in ['OSTI_USERNAME', 'OSTI_PASSWORD']]
+        assert all([var in os.environ for var in environment_vars]), \
+            f'All {mode} environment variables need to be set. ' \
+            f'See the README for more information.'
 
         # Assign username and password depending on where data is being posted
-        if mode == 'test':
-            self.username = os.environ['OSTI_USERNAME_TEST']
-            self.password = os.environ['OSTI_PASSWORD_TEST']
-        elif mode == 'prod':
-            self.username = os.environ['OSTI_USERNAME_PROD']
-            self.password = os.environ['OSTI_PASSWORD_PROD']
+        if mode in ['test', 'prod']:
+            self.username = os.environ[f'OSTI_USERNAME_{mode.upper()}']
+            self.password = os.environ[f'OSTI_PASSWORD_{mode.upper()}']
         else:
             self.username, self.password = None, None
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ We are dependent on [ostiapi](https://github.com/doecode/ostiapi) as a submodule
 pip install -r requirements.txt
 ```
 
-`ostiapi` requires a username and a password, which are different for posting to either test or dev. `Poster.py` searches for four environment variables, listed below. After a user gets an ELink Account, one can set the appropriate variables in `secrets.sh`, which is already removed from version control by `.gitignore`.
+`ostiapi` requires a username and a password, which are different for posting to either `test` or `prod`.
+`Poster.py` searches for two environment variables for the appropriate `mode` (`test`/`prod`).
+After a user gets an E-Link Account, one can set the appropriate variables in `secrets.sh`,
+which is already removed from version control by `.gitignore`.
 
 ```
 export OSTI_USERNAME_TEST="my-test-osti-username"


### PR DESCRIPTION
Closes #53

This will only check for a user/name for either test/production. Also includes some minor improvements for instance variables setting. README.md updated to reflect changes.

