### PR TITLE
Add cronjob event trigger for smoke tests

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -1,6 +1,10 @@
 name: smoke-test
 
-on: [push]
+on:
+  push:
+  schedule:
+    # First of the month at 7AM
+    - cron: "0 11 1 * *"
 
 jobs:
   smoke-test:


### PR DESCRIPTION
Closes #48 

This ensures that we run the smoke test monthly on the 1st. Why? Two reasons:
1. When new collections are created, it is often the case that we forget to update the repo. This often causes Scraper.py to fail. This will remind us.
2. As an added benefit, we will be able to see how many new deposits for the month and hence the fiscal year.