### PR TITLE
Use funding metadata in DataSpace for OSTI submissions

### DIFF
--- a/Poster.py
+++ b/Poster.py
@@ -57,7 +57,7 @@ class Poster:
         with open(self.to_upload) as f:
             to_upload_j = json.load(f)
 
-        df = pd.read_csv(self.form_input, sep='\t')
+        df = pd.read_csv(self.form_input, sep='\t', keep_default_na=False)
         df = df.set_index('DSpace ID')
 
         # Validate Input CSV 
@@ -110,6 +110,7 @@ class Poster:
                 'research_org': 'PPPL',
                 'accession_num': dspace_data['handle'],
                 'publication_date': pub_date,
+                'othnondoe_contract_nos': row['Non-DOE Contract'],
             }
 
             # Collect optional required information
@@ -149,6 +150,7 @@ class Poster:
                     "title": record["title"],
                     "contract_nos": "AC02-09CH11466",
                     "other_identifying_nos": None,
+                    "othnondoe_contract_nos": "",
                     "doi": "10.11578/1488485",
                     "doi_status": "PENDING",
                     "status": "SUCCESS",

--- a/Poster.py
+++ b/Poster.py
@@ -1,18 +1,20 @@
+import datetime
 import json
 import os
-import datetime
-import argparse
 import sys
 
 import pandas as pd
 
 import ostiapi
 
+
 class Poster:
     """Use the form input and DSpace metadata to generate the JSON necessary
      for OSTI ingestion. Then post to OSTI using their API"""
-    def __init__(self, mode, data_dir='data', to_upload='dataset_metadata_to_upload.json',
-     form_input_full_path='form_input.tsv', osti_upload='osti.json', response_dir="responses"):
+    def __init__(
+        self, mode, data_dir='data', to_upload='dataset_metadata_to_upload.json',
+        form_input_full_path='form_input.tsv', osti_upload='osti.json', response_dir="responses"
+    ):
         self.mode = mode
 
         # Prepare all paths
@@ -21,8 +23,10 @@ class Poster:
         self.to_upload = os.path.join(data_dir, to_upload)
         self.osti_upload = os.path.join(data_dir, osti_upload)
 
-        self.response_output = os.path.join(response_dir,
-            f"{mode}_osti_response_{str(datetime.datetime.now()).replace(':', '')}.json")
+        self.response_output = os.path.join(
+            response_dir,
+            f"{mode}_osti_response_{str(datetime.datetime.now()).replace(':', '')}.json"
+        )
 
         assert os.path.exists(data_dir)
         assert os.path.exists(response_dir)
@@ -61,13 +65,19 @@ class Poster:
             return series.shape[0] == series.dropna().shape[0]
 
         expected_columns = ['Sponsoring Organizations', 'DOE Contract', 'Datatype']
-        assert all([col in df.columns for col in expected_columns]), f"You're missing one of these columns {expected_columns}"
-        assert no_empty_cells(df['Sponsoring Organizations']), f"You have empty values in the Sponsoring Organizations column. This is a required value."
-        assert no_empty_cells(df['DOE Contract']), f"You have empty values in the DOE Contract column. This is a required value."
-        assert no_empty_cells(df['Datatype']), f"You have empty values in the Datatype column. This is a required value."
+        assert all([col in df.columns for col in expected_columns]), \
+            f"You're missing one of these columns {expected_columns}"
+        assert no_empty_cells(df['Sponsoring Organizations']), \
+            f"You have empty values in the Sponsoring Organizations column. This is a required value."
+        assert no_empty_cells(df['DOE Contract']), \
+            f"You have empty values in the DOE Contract column. This is a required value."
+        assert no_empty_cells(df['Datatype']), \
+            f"You have empty values in the Datatype column. This is a required value."
 
-        accepted_datatype_values = ['AS','GD', 'IM', 'ND', 'IP', 'FP', 'SM', 'MM', 'I']
-        assert all([dt in accepted_datatype_values for dt in df['Datatype']]), f"The Datatype column contains improper datatype values. The accepted datatype values are: {accepted_datatype_values}"
+        accepted_datatype_values = ['AS', 'GD', 'IM', 'ND', 'IP', 'FP', 'SM', 'MM', 'I']
+        assert all([dt in accepted_datatype_values for dt in df['Datatype']]), \
+            "The Datatype column contains improper datatype values. " \
+            f"The accepted datatype values are: {accepted_datatype_values}"
 
         # Generate final JSON to post to OSTI
         osti_format = []
@@ -86,14 +96,20 @@ class Poster:
             # Collect all required information
             item_dict = {
                 'title': dspace_data['name'],
-                'creators': ';'.join([m['value'] for m in dspace_data['metadata'] if m['key'] == 'dc.contributor.author']),
+                'creators': ';'.join(
+                    [
+                        m['value']
+                        for m in dspace_data['metadata']
+                        if m['key'] == 'dc.contributor.author'
+                    ]
+                ),
                 'dataset_type': row['Datatype'],
                 'site_url': "https://dataspace.princeton.edu/handle/" + dspace_data['handle'],
                 'contract_nos': row['DOE Contract'],
                 'sponsor_org': row['Sponsoring Organizations'],
                 'research_org': 'PPPL',
                 'accession_num': dspace_data['handle'],
-                'publication_date': pub_date
+                'publication_date': pub_date,
             }
 
             # Collect optional required information
@@ -121,8 +137,8 @@ class Poster:
         with open(self.osti_upload, 'w') as f:
             json.dump(osti_format, f, indent=4)
 
-
-    def _fake_post(self, records, username, password):
+    @staticmethod
+    def _fake_post(records):
         """A fake JSON response that mirrors OSTI's"""
         return {
             "record": [
@@ -142,7 +158,6 @@ class Poster:
             ]
         }
 
-
     def post_to_osti(self):
         """Post the collected metadata to OSTI's test or prod server. If in
          dry-run mode, call our _fake_post method"""
@@ -154,7 +169,7 @@ class Poster:
 
         print('Posting data...')
         if self.mode == 'dry-run':
-            response_data = self._fake_post(osti_j, self.username, self.password)
+            response_data = self._fake_post(osti_j)
         else:
             response_data = ostiapi.post(osti_j, self.username, self.password)
 
@@ -172,10 +187,11 @@ class Poster:
             if all([item['status'] == 'SUCCESS' for item in response_data['record']]):
                 print("Congrats 🚀 OSTI says that all records were successfully uploaded!")
             else:
-                print("Some of OSTI's responses do not have 'SUCCESS' as their" +
+                print(
+                    "Some of OSTI's responses do not have 'SUCCESS' as their" +
                     f" status. Look at the file {self.response_output} to" +
-                    " see which records were not successfully uploaded.")
-
+                    " see which records were not successfully uploaded."
+                )
 
     def run_pipeline(self):
         self.generate_upload_json()

--- a/Scraper.py
+++ b/Scraper.py
@@ -31,7 +31,8 @@ PPPL_COLLECTIONS = {
 
 PPPL_COMMUNITY_ID = 346
 
-REGEX_DOE = r"^(DE|AC|SC|FC|FG|AR|EE|EM|FE|NA|NE)"  # All possible prefix
+# All possible prefix
+REGEX_DOE = r"^(DE|AC|SC|FC|FG|AR|EE|EM|FE|NA|NE)"  # https://regex101.com/r/SxNHJg/2
 REGEX_DOE_SUB = "^(DE)+(-?)"  # https://regex101.com/r/NsZbRJ/2
 REGEX_FUNDING = r"\b(?:[A-Z0-9\/\-]{6,})"  # https://regex101.com/r/4fNYVm/3
 
@@ -210,8 +211,8 @@ class Scraper:
         ]
         funding_source_dict = list(map(get_doe_funding, funding_result_simple))
 
-        df['DOE Contract'] = [d.get("doe") for d in funding_source_dict]
-        df['Non-DOE Contract'] = [d.get("other") for d in funding_source_dict]
+        df['DOE Contract'] = [";".join(d.get("doe")) for d in funding_source_dict]
+        df['Non-DOE Contract'] = [";".join(d.get("other")) for d in funding_source_dict]
 
         # Sponsoring organizations is always Office of Science
         df['Sponsoring Organizations'] = "USDOE Office of Science (SC)"
@@ -279,23 +280,23 @@ def get_funder(text: str) -> list:
     return [m.group() for m in matches]
 
 
-def get_doe_funding(grant_nos: str) -> Dict[str, list]:
+def get_doe_funding(grant_nos: str) -> Dict[str, set]:
     """Separate DOE from other funding. Prefix DE prefix"""
 
     grant_dict = {
-        "doe": [],
-        "other": [],
+        "doe": set(),
+        "other": set(),
     }
 
     if not grant_nos:  # Empty case
-        grant_dict["doe"] = "AC02-09CH11466"
+        grant_dict["doe"].update(["AC02-09CH11466"])
     else:
         grants = grant_nos.split(";")
         for grant in grants:
             if re.match(REGEX_DOE, grant):
-                grant_dict["doe"].append(re.sub(REGEX_DOE_SUB, "", grant))
+                grant_dict["doe"].update([re.sub(REGEX_DOE_SUB, "", grant)])
             else:
-                grant_dict["other"].append(grant)
+                grant_dict["other"].update([grant])
 
     return grant_dict
 

--- a/Scraper.py
+++ b/Scraper.py
@@ -36,6 +36,18 @@ REGEX_DOE = r"^(DE|AC|SC|FC|FG|AR|EE|EM|FE|NA|NE)"  # https://regex101.com/r/SxN
 REGEX_DOE_SUB = "^(DE)+(-?)"  # https://regex101.com/r/NsZbRJ/2
 REGEX_FUNDING = r"\b(?:[A-Z0-9\/\-]{6,})"  # https://regex101.com/r/4fNYVm/3
 
+REPLACE_DICT = {
+    '- ': '-',  # Extra white space inside DoE grant
+    'AC02 ': 'AC02-',  # Missing hyphen
+    'AC-02': 'AC02',  # Extra hyphen
+    'SC-0': 'SC0',  # Extra hyphen for Office of Science grants
+    'DC': 'DE',  # Common typo
+    'DE ': 'DE',  # Extra white space
+    'DOE-': 'DE',  # Proper prefix
+    'DOE ': '',  # Extra DOE
+    'DOE': '',  # Remove DOE if still present
+}
+
 
 class Scraper:
     """
@@ -275,6 +287,13 @@ class Scraper:
 
 def get_funder(text: str) -> list:
     """Aggregate funding grant numbers from text"""
+
+    # Clean up text by fixing any whitespace to get full grant no.
+    for key, value in REPLACE_DICT.items():
+        text = text.replace(key, value)
+
+    for hyphen in ["\u2010", "\u2013"]:
+        text = text.replace(hyphen, '-')
 
     matches = re.finditer(REGEX_FUNDING, text)
     return [m.group() for m in matches]


### PR DESCRIPTION
Closes #66

This PR uses the `dc.contributor.funder` key fields from the DataSpace REST API metadata and uses `regex` to find grant numbers. These numbers are then split between DOE and non-DOE (e.g., NSF) grant numbers. These grants are then populated in the `contract_nos` and `othnondoe_contract_nos` records fields for the API submission.

- [x] Inspect `osti.json`
- [ ] Do a E-Link 241.6 test submission to ensure it's properly captured
